### PR TITLE
switch course package list api to fetch 'all'

### DIFF
--- a/src/Data/Package.elm
+++ b/src/Data/Package.elm
@@ -43,7 +43,7 @@ retrievePackages token baseUrl =
             ]
 
         url =
-            baseUrl ++ "/content-service/api/v1/packages/editable"
+            baseUrl ++ "/content-service/api/v1/packages"
     in
     Http.request
         { method = "GET"


### PR DESCRIPTION
This PR adds change to ensure authoring-admin manages all packages including ones set invisible